### PR TITLE
expoloring more options for standardizing test methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# macOS files
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+# conftest.py is the config file for pytest
+
+# access directory of
+@pytest.fixture('session')
+def test_data_dir_path():
+    return Path(__file__).name.joinpath('test_data')

--- a/tests/test_applescript.py
+++ b/tests/test_applescript.py
@@ -1,0 +1,50 @@
+# ============ imports ============ #
+from pathlib import Path
+from platform import platform
+from subprocess import PIPE, run
+
+import pytest
+
+if not operating_platform.lower().startswith('darwin'): # it's NOT macOS
+    print('AppleScript is only present on macOS')
+    exit()
+
+def process(input, script=False, args=None):
+    '''
+    Function to parse input and send it to osascript
+
+    If script=True, then input is the path to a script
+    and args will be parsed.
+
+    Otherwise, input will
+    '''
+    command_list = ['osascript']
+
+    if script:  # then input is a /path/to/an/AppleScript
+        script_path = input
+
+        # I use Paths quite a bit so cast script_path as a str ensure proper type
+        command_list.append(str(script_path))
+
+        if args:
+            if isinstance(args, list):
+                for arg in args:
+                    command_list.append(arg)
+            else:
+                command_list.append(args)
+
+    else:  # input is list or string
+        if isinstance(input, list):
+            for line in input:
+                command_list.append('-e').append(line)
+        else:  # it's a single string
+            command_list.append('-e').append(input)
+
+    # run the command and store the result
+    applescript_subprocess_result = run(command_list,
+                                        encoding = 'utf-8',
+                                        stdout = PIPE,
+                                        stderr = PIPE,
+                                        )
+
+    retrun applescript_subprocess_result

--- a/tests/test_jhove.py
+++ b/tests/test_jhove.py
@@ -1,26 +1,27 @@
-import platform
 from pathlib import Path
+from platform import platform
+from subprocess import
 
 import pytest
 
 # get OS -- currently only working with macOS
-operating_platform = platform.platform()
+operating_platform = platform()
 
-if operating_platform.lower().startswith('darwin'):
-    # it's macOS and we'll assume Jhove is installed in default location
+if operating_platform.lower().startswith('darwin'): # it's macOS
+    # assume Jhove is installed in default location
     jhove_path = Path.home().joinpath('jhove/jhove')
 else:
     # if it's not macOS, but I don't know where to look for jhove yet
     pass
 
-image_path = Path.cwd()
-
 def does_jhove_exist(jhove_path=jhove_path):
     return jhove_path.is_file()
 
-jhove_module_list = ['tif', 'tiff', 'jpeg2000']
+jhove_module_list = ['tif', 'tiff', 'jp2', 'jpg2000', 'jpeg2000']
 
 def jhove(image_path, jhove_module):
+
+    # get jhove_module submission in lower case and verify in module list
     if jhove_module.lower() not in jhove_module_list:
         print(f'jhove_module "{jhove_module}" not in jhove_module_list')
         print(jhove_module_list)
@@ -29,6 +30,8 @@ def jhove(image_path, jhove_module):
 @pytest.mark.skipif(not jhove_path, reason="not macOS, default jhove path unknown")
 def test_does_jhove_exist():
     assert does_jhove_exist() == True
+
+image_path = test_data_path.joinpath('valid.jp2')
 
 @pytest.mark.skipif(does_jhove_exist()==False, reason="jhove not installed in default location")
 def test_jhove():


### PR DESCRIPTION
added conftest.py with @pytest.fixture() to return the test_data directory

Need to add valid and invalid JPEG2000 for tests! -- use inside back cover from athletic program that's just blank. Need to add multiple JPEG2000 types, though, too. Would rather have a single image that we convert multiple ways/times unless there's a reason to use something else